### PR TITLE
Fix JstdConfigurationType factory default `getId`

### DIFF
--- a/JsTestDriver/plugin/src/main/java/com/google/jstestdriver/idea/execution/JstdConfigurationType.java
+++ b/JsTestDriver/plugin/src/main/java/com/google/jstestdriver/idea/execution/JstdConfigurationType.java
@@ -45,6 +45,12 @@ public final class JstdConfigurationType extends ConfigurationTypeBase implement
       public RunConfigurationSingletonPolicy getSingletonPolicy() {
         return RunConfigurationSingletonPolicy.SINGLE_INSTANCE_ONLY;
       }
+      
+      @NotNull
+      @Override
+      public String getId() {
+        return NAME;
+      }
     });
   }
 


### PR DESCRIPTION
com.intellij.diagnostic.PluginException: The default implementation of method 'getId' is deprecated, you need to override it in 'class com.google.jstestdriver.idea.execution.JstdConfigurationType$1'. The default implementation delegates to 'getName' which may be localized, but return value of this method must not depend on current localization. [Plugin: JSTestDriver Plugin]